### PR TITLE
Feat: add conditional baseUrl for development and production environm…

### DIFF
--- a/src/services/youtubeService.tsx
+++ b/src/services/youtubeService.tsx
@@ -11,11 +11,20 @@ export const fetchMp3Link = async (youtubeID: string): Promise<string> => {
     } as ErrorResponse;
   }
 
+  const baseUrl =
+    import.meta.env.MODE === "development"
+      ? "/api/youtube-mp3/dl"
+      : "https://youtube-mp36.p.rapidapi.com/dl";
+
   const options = {
     method: "GET",
-    url: "/api/youtube-mp3/dl",
+    url: baseUrl,
     params: {
       id: youtubeID,
+    },
+    headers: {
+      "X-RapidAPI-Key": apiKey,
+      "X-RapidAPI-Host": "youtube-mp36.p.rapidapi.com",
     },
   };
 


### PR DESCRIPTION
- Implemented conditional logic to handle different base URLs for development and production.
- In development mode, requests use the Vite proxy endpoint `/api/youtube-mp3/dl`.
- In production mode, requests are sent directly to the external API at `https://youtube-mp36.p.rapidapi.com/dl`.
- Added necessary headers for RapidAPI authentication in both environments.